### PR TITLE
fix: single file foldered games download

### DIFF
--- a/lib/core/downloader/download_service.dart
+++ b/lib/core/downloader/download_service.dart
@@ -78,7 +78,14 @@ class DownloadService {
       return;
     }
 
-    final finalPath = await directoryService.getRomFilePath(game);
+
+    bool isSingleFileFoldered = game.files.length == 1 && game.fsExtension == '';
+
+    String finalPath = await directoryService.getRomFilePath(game);
+    if (isSingleFileFoldered) {
+      final fileName = game.files[0]["file_name"];
+      finalPath = '$finalPath/$fileName';
+    }
     final partPath = '$finalPath.part';
     final partFile = File(partPath);
     await partFile.parent.create(recursive: true);
@@ -222,12 +229,10 @@ class DownloadService {
         // 1. It's a multi-file game (RomM says it has multiple files)
         // 2. It's a Windows game in an archive (usually needs extraction to run an EXE)
         // 3. It's a ZIP/archive but the platform emulator DOES NOT support archives natively
-        // 4: It's a single file game in a folder. (RomM says it's not multi, but has an empty fs_extension, and there's only 1 file)
         final shouldExtract = game.isMultiFile || 
                              (isWindowsGame && isArchive) || 
-                             ((isZipSignature || isArchive) && !platformSupportsArchive) ||
-                             game.files.length == 1 && game.fsExtension == '';
-        
+                             ((isZipSignature || isArchive) && !platformSupportsArchive);
+
         if (shouldExtract) {
           final extension = currentPath.split('.').last.toLowerCase();
           yield DownloadProgress(

--- a/lib/core/downloader/download_service.dart
+++ b/lib/core/downloader/download_service.dart
@@ -222,9 +222,11 @@ class DownloadService {
         // 1. It's a multi-file game (RomM says it has multiple files)
         // 2. It's a Windows game in an archive (usually needs extraction to run an EXE)
         // 3. It's a ZIP/archive but the platform emulator DOES NOT support archives natively
+        // 4: It's a single file game in a folder. (RomM says it's not multi, but has an empty fs_extension, and there's only 1 file)
         final shouldExtract = game.isMultiFile || 
                              (isWindowsGame && isArchive) || 
-                             ((isZipSignature || isArchive) && !platformSupportsArchive);
+                             ((isZipSignature || isArchive) && !platformSupportsArchive) ||
+                             game.files.length == 1 && game.fsExtension == '';
         
         if (shouldExtract) {
           final extension = currentPath.split('.').last.toLowerCase();

--- a/lib/core/romm/romm_models.dart
+++ b/lib/core/romm/romm_models.dart
@@ -10,6 +10,7 @@ class Game {
   final String? fileUrl; // Now nullable, to be replaced by constructed URL
   final String? fileName; // Added: maps to 'file_name' in JSON
   final String? fsName; // Added: maps to 'fs_name' in JSON
+  final String? fsExtension; // maps to 'fs_extension' in JSON
   final int fileSize; // Kept
   final String? multiFilePath; // maps to 'multi_file_path' in JSON
   final bool hasMultipleFiles;
@@ -71,6 +72,7 @@ class Game {
     this.fileUrl, // Now nullable
     this.fileName, // Added
     this.fsName, // Added
+    this.fsExtension,
     required this.fileSize, // Kept
     this.multiFilePath,
     this.hasMultipleFiles = false,
@@ -109,6 +111,7 @@ class Game {
       fileUrl: json['url_download']?.toString(), // Maps to original download URL, if present
       fileName: json['file_name']?.toString(), // Mapped from JSON
       fsName: json['fs_name']?.toString(), // Mapped from JSON
+      fsExtension: json['fs_extension']?.toString(),
       fileSize: json['file_size_bytes'] is int ? json['file_size_bytes'] : 0,
       multiFilePath: json['multi_file_path']?.toString(),
       hasMultipleFiles: json['has_multiple_files'] as bool? ?? false,


### PR DESCRIPTION
If a game with a single file is inside a folder, it fails to download since Romm doesn't mark it as multi but also does not give it a file extension.

Fix this by saving it to `path\gameName\fileName.extension`, replicating the server-side folder structure.

Fixes #29