### PR TITLE
fix: Changed Dolphin Download page's query params to avoid redirects

### DIFF
--- a/lib/core/emulator/release_service.dart
+++ b/lib/core/emulator/release_service.dart
@@ -138,7 +138,7 @@ class ReleaseService {
 
   Future<List<Map<String, String>>> _scrapeDolphin(List<String> requiredFilters, List<String> excludedFilters) async {
     try {
-      final response = await http.get(Uri.parse('https://dolphin-emu.org/download/'), headers: {'User-Agent': 'Freegosy', 'Accept-Language': 'en-US'});
+      final response = await http.get(Uri.parse('https://dolphin-emu.org/download/?nocr=true'), headers: {'User-Agent': 'Freegosy', 'Accept-Language': 'en-US'});
       // Accept any 2xx status; Dolphin's site may 302-redirect based on locale.
       if (response.statusCode < 200 || response.statusCode >= 300) return [];
 


### PR DESCRIPTION
Changed the download link to Dolphin's website to : 

https://dolphin-emu.org/download/?nocr=true

The nocr param should prevent the website to redirect the user in case they have a different locale than en-US... Normally...