### PR TITLE
fix: Using "windows_native" emulator strategy ID in save strategy method

### DIFF
--- a/lib/core/save/save_sync_service.dart
+++ b/lib/core/save/save_sync_service.dart
@@ -222,7 +222,7 @@ class SaveSyncService {
     if (id == 'xenia' || id == 'xenia_canary') return _xenia;
     if (id == 'eden') return _eden;
     if (id == 'ryujinx') return _ryujinx;
-    if (id == 'windows') return _windows;
+    if (id == 'windows_native') return _windows;
     if (id == 'azahar') return _azahar;
     if (id == 'ares') return _ares;
     return null;


### PR DESCRIPTION
Should fix the save sync for Windows Native games, tested on my side, and it worked