### PR TITLE
Fix linux emu support folder

### DIFF
--- a/lib/core/emulator/linux_strategies/native_linux_strategy.dart
+++ b/lib/core/emulator/linux_strategies/native_linux_strategy.dart
@@ -29,6 +29,26 @@ class NativeLinuxStrategy extends LinuxEnvironmentStrategy {
 
   @override
   String getEmulatorAppSupportDirectory(String home, String emulatorName, String? emudeckRoot, {String? platformSlug}) {
+    // check common configuration directory for flatpak instalations
+    var flatpakPackage = kEmulatorFlatpakPackages[emulatorName];
+    if(flatpakPackage != null) {
+      var supportDirectoryParent = p.join(home, ".var", "app", flatpakPackage, "config");
+      final dir = io.Directory(supportDirectoryParent);
+      if(dir.existsSync()) {
+          for (final entity in dir.listSync()) {  
+            if (entity is io.File) continue;
+            final lowerFolderName = p.basename(entity.path).toLowerCase();
+            if (lowerFolderName == emulatorName.toLowerCase()) {
+              return entity.path;
+            }
+          }
+      }
+    }
+    // check common configuration directory for app image instalations
+    var altSupportDirectoryPath =  p.join(home, '.local', 'share', emulatorName.toLowerCase());
+    if(io.Directory(altSupportDirectoryPath).existsSync()) {
+          return altSupportDirectoryPath;
+    }
     return p.join(home, '.config', emulatorName);
   }
 

--- a/lib/core/emulator/linux_strategies/native_linux_strategy.dart
+++ b/lib/core/emulator/linux_strategies/native_linux_strategy.dart
@@ -30,7 +30,8 @@ class NativeLinuxStrategy extends LinuxEnvironmentStrategy {
   @override
   String getEmulatorAppSupportDirectory(String home, String emulatorName, String? emudeckRoot, {String? platformSlug}) {
     // check common configuration directory for flatpak instalations
-    var flatpakPackage = kEmulatorFlatpakPackages[emulatorName];
+    var lowerCaseEmulatorName = emulatorName.toLowerCase();
+    var flatpakPackage = kEmulatorFlatpakPackages[lowerCaseEmulatorName];
     if(flatpakPackage != null) {
       var supportDirectoryParent = p.join(home, ".var", "app", flatpakPackage, "config");
       final dir = io.Directory(supportDirectoryParent);
@@ -38,14 +39,14 @@ class NativeLinuxStrategy extends LinuxEnvironmentStrategy {
           for (final entity in dir.listSync()) {  
             if (entity is io.File) continue;
             final lowerFolderName = p.basename(entity.path).toLowerCase();
-            if (lowerFolderName == emulatorName.toLowerCase()) {
+            if (lowerFolderName == lowerCaseEmulatorName) {
               return entity.path;
             }
           }
       }
     }
     // check common configuration directory for app image instalations
-    var altSupportDirectoryPath =  p.join(home, '.local', 'share', emulatorName.toLowerCase());
+    var altSupportDirectoryPath =  p.join(home, '.local', 'share', lowerCaseEmulatorName);
     if(io.Directory(altSupportDirectoryPath).existsSync()) {
           return altSupportDirectoryPath;
     }

--- a/lib/ui/screens/library_actions.dart
+++ b/lib/ui/screens/library_actions.dart
@@ -13,6 +13,7 @@ import '../../providers/ui_provider.dart';
 import '../../providers/download_provider.dart';
 import '../../providers/romm_provider.dart';
 import '../../core/romm/romm_service.dart';
+import '../../core/romm/rom_constants.dart';
 import '../../providers/shared_prefs_provider.dart';
 import '../../providers/downloaded_games_cache_provider.dart';
 import '../../core/storage/directory_service.dart';
@@ -412,6 +413,26 @@ mixin LibraryActionsMixin<T extends ConsumerStatefulWidget> on ConsumerState<T> 
         debugPrint('[Launch] No files available for multi-file game, using romPath: $romPath');
       }
     }
+
+    // If romPath points to a directory try to find the actual rom inside it, unless platform is windows (folder based games)
+    if(await io.Directory(romPath).exists()) {
+        var lowerPlatformSlug = game.platformSlug!.toLowerCase();
+        if (!["windows", "pc", "win"].contains(lowerPlatformSlug)){
+          debugPrint('[Launch] Searching for a valid rom in: $romPath');
+          var knownExtensions = RomConstants.platformExtensions[lowerPlatformSlug] ?? [];
+          final dir = io.Directory(romPath);
+          await for (final entity in dir.list()) {  
+            if (entity is! io.File) continue;
+            final name = p.basename(entity.path).toLowerCase();
+            if (knownExtensions.where((ext) => name.endsWith(ext)).isNotEmpty) {
+              romPath = entity.path;
+              debugPrint('[Launch] Matched rom by extension: $romPath');
+              break;
+            }
+          }
+        }
+    }
+
 
     if (!await io.File(romPath).exists() && !await io.Directory(romPath).exists()) {
        if (context.mounted) ErrorHandler.showInfo(context, 'File Not Found', message: 'The ROM was not found at the expected location.');


### PR DESCRIPTION
Hello,

I will like to add these changes that I've to make for the emulator support directory to be correctly detected on my system. With these my saves are correctly pushed to the server.

I've tested this changes using fedora 44 KDE with Eden (AppImage) DuckStation (AppImage). PCSX2 (Flatpak) and PPSSPP (Flatpak).

I've also added an additional commit that improves the rom file detection when it's inside a folder.

I hope the changes are fine. 

Best regards and ty for this app.