### PR TITLE
fix: check flatpak dolphin support folder on linux

### DIFF
--- a/lib/core/emulator/linux_strategies/native_linux_strategy.dart
+++ b/lib/core/emulator/linux_strategies/native_linux_strategy.dart
@@ -36,10 +36,11 @@ class NativeLinuxStrategy extends LinuxEnvironmentStrategy {
       var supportDirectoryParent = p.join(home, ".var", "app", flatpakPackage, "config");
       final dir = io.Directory(supportDirectoryParent);
       if(dir.existsSync()) {
+          var lowerAppName = flatpakPackage.split('.').last.toLowerCase();
           for (final entity in dir.listSync()) {  
             if (entity is io.File) continue;
             final lowerFolderName = p.basename(entity.path).toLowerCase();
-            if (lowerFolderName == lowerCaseEmulatorName) {
+            if (lowerFolderName == lowerAppName) {
               return entity.path;
             }
           }


### PR DESCRIPTION
@abduznik I tested the changes from https://github.com/abduznik/Freegosy/pull/71 with Cemu and it worked (Duckstation flatpack package is not longer available I think) but for dolphin (folder name dolphin-emu) it doesn't work. Using the name extracted from the flatpak package seems to fix the issue.