### PR TITLE
Fix: retroarch save strategy save directory mapping for non-emudeck linux

### DIFF
--- a/lib/core/save/strategies/retroarch_save_strategy.dart
+++ b/lib/core/save/strategies/retroarch_save_strategy.dart
@@ -145,7 +145,7 @@ class RetroArchSaveStrategy extends SaveStrategy {
 
   /// Save file extensions recognized by RetroArch cores.
   /// N64 cores use .sra/.eep/.fla/.mpk; most others use .srm/.sav/.mcd.
-  static const _saveExtensions = {'.srm', '.sav', '.mcd', '.sra', '.eep', '.fla', '.mpk'};
+  static const _saveExtensions = {'.srm', '.sav', '.mcd', '.sra', '.eep', '.fla', '.mpk', '.ps2'};
 
   static bool _isSaveFile(String filename) {
     final ext = p.extension(filename).toLowerCase();

--- a/lib/core/save/strategies/retroarch_save_strategy.dart
+++ b/lib/core/save/strategies/retroarch_save_strategy.dart
@@ -460,8 +460,9 @@ class RetroArchSaveStrategy extends SaveStrategy {
       // Non-EmuDeck Linux: respect sort_savefiles_enable config flag
       if (!_sortSavefiles) {
         // sort_savefiles_enable=false: saves go flat into baseDir, no core subfolder
+        final result = p.join(baseDir, 'saves');
         debugPrint('[SaveSync] [retroarch] getSaveDir linux no-sort → $baseDir');
-        return baseDir;
+        return result;
       }
       // Non-EmuDeck Linux: mapping returns the folder containing the actual saves
       final result = p.join(baseDir, 'saves', coreInfo.saveFolder);

--- a/lib/core/save/strategies/retroarch_save_strategy.dart
+++ b/lib/core/save/strategies/retroarch_save_strategy.dart
@@ -457,17 +457,49 @@ class RetroArchSaveStrategy extends SaveStrategy {
         return result;
       }
 
+      // Non-EmuDeck Linux: prefer the parsed savefile_directory from retroarch.cfg
+      // (honors custom save locations); fall back to baseDir/saves otherwise.
+      final saveRoot = (_cachedSaveRoot != null && await io.Directory(_cachedSaveRoot!).exists())
+          ? _cachedSaveRoot!
+          : p.join(baseDir, 'saves');
+      debugPrint('[SaveSync] [retroarch] getSaveDir linux saveRoot=$saveRoot');
+
       // Non-EmuDeck Linux: respect sort_savefiles_enable config flag
       if (!_sortSavefiles) {
-        // sort_savefiles_enable=false: saves go flat into baseDir, no core subfolder
-        final result = p.join(baseDir, 'saves');
-        debugPrint('[SaveSync] [retroarch] getSaveDir linux no-sort → $baseDir');
-        return result;
+        // sort_savefiles_enable=false: saves go flat into saveRoot, no core subfolder
+        debugPrint('[SaveSync] [retroarch] getSaveDir linux no-sort → $saveRoot');
+        return saveRoot;
       }
-      // Non-EmuDeck Linux: mapping returns the folder containing the actual saves
-      final result = p.join(baseDir, 'saves', coreInfo.saveFolder);
-      debugPrint('[SaveSync] [retroarch] getSaveDir linux sorted → $result');
-      return result;
+
+      // Try the expected core subfolder first
+      final expectedDir = p.join(saveRoot, coreInfo.saveFolder);
+      if (await io.Directory(expectedDir).exists()) {
+        debugPrint('[SaveSync] [retroarch] getSaveDir linux expectedDir exists → $expectedDir');
+        return expectedDir;
+      }
+
+      // Fallback: scan saveRoot subdirectories for the ROM's save file, since
+      // RetroArch core folder names are unpredictable (e.g. "ParaLLEl N64"
+      // vs "Parallel N64" vs "N64").
+      final romStem = p.basenameWithoutExtension(romPath).toLowerCase();
+      final rootDir = io.Directory(saveRoot);
+      if (await rootDir.exists()) {
+        await for (final entity in rootDir.list()) {
+          if (entity is! io.Directory) continue;
+          final subdir = entity.path;
+          await for (final f in io.Directory(subdir).list()) {
+            if (f is! io.File) continue;
+            final fname = p.basename(f.path).toLowerCase();
+            if (fname.startsWith(romStem) && _isSaveFile(fname)) {
+              debugPrint('[SaveSync] [retroarch] getSaveDir linux fallback scan matched → $subdir');
+              return subdir;
+            }
+          }
+        }
+      }
+
+      debugPrint('[SaveSync] [retroarch] getSaveDir linux fallback expectedDir → $expectedDir');
+      return expectedDir;
     }
 
     // macOS / Windows: respect sort_savefiles_enable config flag

--- a/lib/core/save/strategies/retroarch_save_strategy.dart
+++ b/lib/core/save/strategies/retroarch_save_strategy.dart
@@ -463,8 +463,8 @@ class RetroArchSaveStrategy extends SaveStrategy {
         debugPrint('[SaveSync] [retroarch] getSaveDir linux no-sort → $baseDir');
         return baseDir;
       }
-      // EmuDeck mapping returns the folder containing the actual saves
-      final result = p.join(baseDir, coreInfo.saveFolder);
+      // Non-EmuDeck Linux: mapping returns the folder containing the actual saves
+      final result = p.join(baseDir, 'saves', coreInfo.saveFolder);
       debugPrint('[SaveSync] [retroarch] getSaveDir linux sorted → $result');
       return result;
     }

--- a/test/unit/retroarch_config_parsing_test.dart
+++ b/test/unit/retroarch_config_parsing_test.dart
@@ -74,11 +74,12 @@ void main() {
       final game = Game(id: '1', name: 'Pokemon', platformSlug: 'gba', fileSize: 0);
       final romPath = p.join(tempDir.path, 'roms', 'Pokemon.gba');
       final result = await strategy.getSaveDir(game, romPath);
+      final expected = p.join(configDir, 'saves');
 
       expect(result, isNotNull);
       expect(result, isNot(endsWith('mGBA')),
           reason: 'sort_savefiles_enable=false must NOT append core subfolder');
-      expect(result, equals(configDir),
+      expect(result, equals(expected),
           reason: 'Should return the base dir without core subfolder');
 
       await tempDir.delete(recursive: true);

--- a/test/unit/retroarch_config_parsing_test.dart
+++ b/test/unit/retroarch_config_parsing_test.dart
@@ -74,13 +74,12 @@ void main() {
       final game = Game(id: '1', name: 'Pokemon', platformSlug: 'gba', fileSize: 0);
       final romPath = p.join(tempDir.path, 'roms', 'Pokemon.gba');
       final result = await strategy.getSaveDir(game, romPath);
-      final expected = p.join(configDir, 'saves');
 
       expect(result, isNotNull);
       expect(result, isNot(endsWith('mGBA')),
           reason: 'sort_savefiles_enable=false must NOT append core subfolder');
-      expect(result, equals(expected),
-          reason: 'Should return the base dir without core subfolder');
+      expect(result, equals(p.join(tempDir.path, 'saves')),
+          reason: 'Should return the configured savefile_directory without core subfolder');
 
       await tempDir.delete(recursive: true);
     });
@@ -110,6 +109,28 @@ void main() {
       expect(result, isNotNull);
       expect(result, endsWith('mGBA'),
           reason: 'Default should be true (append core subfolder)');
+
+      await tempDir.delete(recursive: true);
+    });
+
+    test('no retroarch.cfg falls back to baseDir/saves/CoreName (Linux)', () async {
+      final tempDir = await Directory.systemTemp.createTemp('ra_no_cfg_');
+      final configDir = p.join(tempDir.path, '.config', 'retroarch');
+      await Directory(p.join(configDir, 'saves', 'mGBA')).create(recursive: true);
+
+      when(mockDirService.getEmulatorAppSupportDirectory('retroarch', platformSlug: anyNamed('platformSlug')))
+          .thenAnswer((_) async => configDir);
+
+      final platform = PlatformInfo('linux', environment: {'HOME': tempDir.path});
+      final strategy = RetroArchSaveStrategy(mockDirService, platform: platform);
+
+      final game = Game(id: '1', name: 'Pokemon', platformSlug: 'gba', fileSize: 0);
+      final romPath = p.join(tempDir.path, 'roms', 'Pokemon.gba');
+      final result = await strategy.getSaveDir(game, romPath);
+
+      expect(result, isNotNull);
+      expect(result, equals(p.join(configDir, 'saves', 'mGBA')),
+          reason: 'Without a custom savefile_directory, saves live under baseDir/saves/CoreName');
 
       await tempDir.delete(recursive: true);
     });


### PR DESCRIPTION
Hi @abduznik,

Thank you for your work on this app, really great so far.

I am submitting this PR to fix the retroarch save strategy for non-emudeck linux.  This PR fixes the save path mapping for retroarch saves which were missing the "saves" part of the path so were being pushed/pulled from `.../retroarch/{CoreName}` instead of  `.../retroarch/saves/{CoreName}` .

Hope the change looks good to you as well, but if not just let me know.

Thanks.