### PR TITLE
Linux Pathing Fixes

### DIFF
--- a/lib/core/emulator/linux_strategies/emudeck_strategy.dart
+++ b/lib/core/emulator/linux_strategies/emudeck_strategy.dart
@@ -183,7 +183,8 @@ class EmuDeckStrategy extends LinuxEnvironmentStrategy {
     } else if (exePath.endsWith('.sh')) {
       await io.Process.start('bash', [exePath, ...args, absRomPath], mode: io.ProcessStartMode.detached);
     } else {
-      await io.Process.start(exePath, [...args, absRomPath], mode: io.ProcessStartMode.detached);
+      final (exe, cmdArgs) = LinuxEnvironmentStrategy.splitCommand(exePath);
+      await io.Process.start(exe, [...cmdArgs, ...args, absRomPath], mode: io.ProcessStartMode.detached);
     }
   }
 
@@ -210,7 +211,8 @@ class EmuDeckStrategy extends LinuxEnvironmentStrategy {
     } else if (exePath.endsWith('.sh')) {
       return await io.Process.start('bash', [exePath, ...args, absRomPath], mode: io.ProcessStartMode.normal);
     } else {
-      return await io.Process.start(exePath, [...args, absRomPath], mode: io.ProcessStartMode.normal);
+      final (exe, cmdArgs) = LinuxEnvironmentStrategy.splitCommand(exePath);
+      return await io.Process.start(exe, [...cmdArgs, ...args, absRomPath], mode: io.ProcessStartMode.normal);
     }
   }
 
@@ -234,8 +236,13 @@ class EmuDeckStrategy extends LinuxEnvironmentStrategy {
     } else if (exePath.endsWith('.sh')) {
       await io.Process.start('bash', [exePath, ...args], mode: io.ProcessStartMode.detached);
     } else {
-      final exeDir = io.File(exePath).parent.path;
-      await io.Process.start(exePath, args, mode: io.ProcessStartMode.detached, workingDirectory: exeDir);
+      final (exe, cmdArgs) = LinuxEnvironmentStrategy.splitCommand(exePath);
+      if (cmdArgs.isNotEmpty) {
+        await io.Process.start(exe, [...cmdArgs, ...args], mode: io.ProcessStartMode.detached);
+      } else {
+        final exeDir = io.File(exe).parent.path;
+        await io.Process.start(exe, args, mode: io.ProcessStartMode.detached, workingDirectory: exeDir);
+      }
     }
   }
 

--- a/lib/core/emulator/linux_strategies/linux_environment_strategy.dart
+++ b/lib/core/emulator/linux_strategies/linux_environment_strategy.dart
@@ -24,6 +24,20 @@ abstract class LinuxEnvironmentStrategy {
   String get name;
   String get id;
 
+  /// Splits an [exePath] into `(executable, leadingArguments)`.
+  ///
+  /// Multi-word commands like `flatpak run org.libretro.RetroArch` must be
+  /// split into separate argv entries before being handed to Process.start —
+  /// passing the whole string as the executable name fails with ENOENT.
+  /// Plain file paths are returned unchanged so spaces inside them are safe.
+  static (String, List<String>) splitCommand(String exePath) {
+    if (exePath.startsWith('flatpak ')) {
+      final parts = exePath.split(' ');
+      return (parts.first, parts.sublist(1));
+    }
+    return (exePath, const []);
+  }
+
   /// Returns the root ROMs directory for this environment.
   String getRomsRoot(String home, String? customPath, String? emudeckRoot);
 

--- a/lib/core/emulator/linux_strategies/native_linux_strategy.dart
+++ b/lib/core/emulator/linux_strategies/native_linux_strategy.dart
@@ -121,14 +121,9 @@ class NativeLinuxStrategy extends LinuxEnvironmentStrategy {
 
   @override
   Future<void> launch(Game game, String romPath, String emulatorId, String exePath, {List<String> args = const []}) async {
-    if (exePath.startsWith('flatpak ')) {
-      // Flatpak launch: split command, append romPath
-      final parts = exePath.split(' ');
-      await io.Process.start(
-        parts.first,
-        [...parts.sublist(1), ...args, romPath],
-        mode: io.ProcessStartMode.detached,
-      );
+    final (exe, cmdArgs) = LinuxEnvironmentStrategy.splitCommand(exePath);
+    if (cmdArgs.isNotEmpty) {
+      await io.Process.start(exe, [...cmdArgs, ...args, romPath], mode: io.ProcessStartMode.detached);
     } else if (exePath.endsWith('.sh')) {
       await io.Process.start('bash', [exePath, ...args, romPath], mode: io.ProcessStartMode.detached);
     } else {
@@ -138,13 +133,9 @@ class NativeLinuxStrategy extends LinuxEnvironmentStrategy {
 
   @override
   Future<io.Process?> launchWithHandle(Game game, String romPath, String emulatorId, String exePath, {List<String> args = const []}) async {
-    if (exePath.startsWith('flatpak ')) {
-      final parts = exePath.split(' ');
-      return await io.Process.start(
-        parts.first,
-        [...parts.sublist(1), ...args, romPath],
-        mode: io.ProcessStartMode.normal,
-      );
+    final (exe, cmdArgs) = LinuxEnvironmentStrategy.splitCommand(exePath);
+    if (cmdArgs.isNotEmpty) {
+      return await io.Process.start(exe, [...cmdArgs, ...args, romPath], mode: io.ProcessStartMode.normal);
     } else if (exePath.endsWith('.sh')) {
       return await io.Process.start('bash', [exePath, ...args, romPath], mode: io.ProcessStartMode.normal);
     } else {
@@ -154,10 +145,9 @@ class NativeLinuxStrategy extends LinuxEnvironmentStrategy {
 
   @override
   Future<void> launchStandalone(String emulatorId, String exePath, {List<String> args = const []}) async {
-    if (exePath.startsWith('flatpak ')) {
-      final parts = exePath.split(' ');
-      await io.Process.start(parts.first, [...parts.sublist(1), ...args],
-        mode: io.ProcessStartMode.detached);
+    final (exe, cmdArgs) = LinuxEnvironmentStrategy.splitCommand(exePath);
+    if (cmdArgs.isNotEmpty) {
+      await io.Process.start(exe, [...cmdArgs, ...args], mode: io.ProcessStartMode.detached);
     } else if (exePath.endsWith('.sh')) {
       await io.Process.start('bash', [exePath, ...args], mode: io.ProcessStartMode.detached);
     } else {

--- a/test/core/emulator/linux_strategies_test.dart
+++ b/test/core/emulator/linux_strategies_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
 import 'package:freegosy/core/emulator/linux_strategies/emudeck_strategy.dart';
+import 'package:freegosy/core/emulator/linux_strategies/linux_environment_strategy.dart';
 import 'package:freegosy/core/emulator/linux_strategies/retrodeck_strategy.dart';
 
 void main() {
@@ -131,6 +132,27 @@ void main() {
         final result = retrodeckStrategy.getBiosPath(tempHome.path, sdCardRoot);
         expect(result, p.join(sdCardRoot, 'bios'));
       });
+    });
+  });
+
+  group('LinuxEnvironmentStrategy.splitCommand', () {
+    test('splits flatpak run commands into executable + arguments', () {
+      final (exe, args) = LinuxEnvironmentStrategy.splitCommand('flatpak run org.libretro.RetroArch');
+      expect(exe, 'flatpak');
+      expect(args, ['run', 'org.libretro.RetroArch']);
+    });
+
+    test('returns plain paths unchanged so spaces are preserved', () {
+      final path = '/home/user/Emulation/tools/launchers/retroarch.sh';
+      final (exe, args) = LinuxEnvironmentStrategy.splitCommand(path);
+      expect(exe, path);
+      expect(args, isEmpty);
+    });
+
+    test('handles flatpak with extra runtime arguments', () {
+      final (exe, args) = LinuxEnvironmentStrategy.splitCommand('flatpak run --branch=stable org.DolphinEmu.dolphin-emu');
+      expect(exe, 'flatpak');
+      expect(args, ['run', '--branch=stable', 'org.DolphinEmu.dolphin-emu']);
     });
   });
 }


### PR DESCRIPTION
## Reason
Had an issue starting games with spaces in the title (eg: 'The Cool Game (USA).iso').

So after some digging I figured that Flatpaks get their executable path set to `flatpak run <package>`. 

`EmudeckStrategy` passed that whole string to `Process.start` as a single executable name, so launching failed with ENOENT.

## Changes

Added `LinuxEnvironmentStrategy.splitCommand()` to split multi-word commands into proper argv entries (plain paths pass through untouched, so spaces in ROM/launcher paths remain safe) and use it in all launch methods of EmuDeckStrategy and NativeLinuxStrategy (deduplicates the inline splits)

## Result
Fixes game launches for titles whose paths contain spaces (e.g. 'Cool Game (USA).chd').

Note: only tested on Linux, and emudeck route 😅 