### PR TITLE
Honor per-game emulator preference in save sync and backup

### DIFF
--- a/lib/core/save/backup_service.dart
+++ b/lib/core/save/backup_service.dart
@@ -36,7 +36,7 @@ class BackupService {
     String? emulatorId,
   }) async {
     try {
-      final strategy = syncService.getStrategyForSlug(game.platformSlug, emulatorId: emulatorId);
+      final strategy = syncService.getStrategyForGame(game, emulatorId: emulatorId);
       if (strategy == null) return null;
 
       // Gather current save files using the same strategy already used for cloud sync
@@ -94,7 +94,7 @@ class BackupService {
     SaveSyncService syncService,
   ) async {
     try {
-      final strategy = syncService.getStrategyForSlug(game.platformSlug);
+      final strategy = syncService.getStrategyForGame(game);
       if (strategy == null) return false;
 
       final saveDir = await strategy.getSaveDir(game, romPath);

--- a/lib/core/save/save_sync_service.dart
+++ b/lib/core/save/save_sync_service.dart
@@ -219,6 +219,20 @@ class SaveSyncService {
     }
   }
 
+  /// Returns the appropriate save strategy for [game], honoring its
+  /// per-game emulator preference before falling back to [getStrategyForSlug]'s
+  /// platform-wide resolution.
+  ///
+  /// [emulatorId], if passed, still wins over any stored preference (it's the
+  /// emulator that actually launched this session, e.g. from the per-game
+  /// picker) — this only fills in the per-game preference for callers that
+  /// don't already know which emulator launched the game (see issue #79).
+  SaveStrategy? getStrategyForGame(Game game, {String? emulatorId}) {
+    final resolvedEmulatorId =
+        emulatorId ?? _strategyRegistry.getGameEmulatorPreference(game.id);
+    return getStrategyForSlug(game.platformSlug, emulatorId: resolvedEmulatorId);
+  }
+
   /// Maps an emulator strategy ID to the corresponding save strategy.
   SaveStrategy? _saveStrategyForEmulatorId(String emulatorId) {
     final id = emulatorId.toLowerCase();
@@ -418,7 +432,7 @@ class SaveSyncService {
   Future<bool> _devicePushSaves(Game game, String romPath,
       {DateTime? sessionStart, String syncMode = 'both', bool force = false, String? coreOverride, String? emulatorId}) async {
     try {
-      final strategy = getStrategyForSlug(game.platformSlug, emulatorId: emulatorId);
+      final strategy = getStrategyForGame(game, emulatorId: emulatorId);
       if (strategy == null) {
         debugPrint('[SaveSync] [push] No save strategy for slug="${game.platformSlug}" — game "${game.displayName}" not supported');
         return false;
@@ -574,7 +588,7 @@ class SaveSyncService {
   Future<bool> _devicePullSave(Game game, String romPath,
       {Map<String, dynamic>? saveData, String? coreOverride, String? emulatorId}) async {
     try {
-      final strategy = getStrategyForSlug(game.platformSlug, emulatorId: emulatorId);
+      final strategy = getStrategyForGame(game, emulatorId: emulatorId);
       if (strategy == null) {
         debugPrint('[SaveSync] [pull] No save strategy for slug="${game.platformSlug}"');
         return false;
@@ -661,7 +675,7 @@ class SaveSyncService {
   Future<bool> _legacyPushSaves(Game game, String romPath,
       {DateTime? sessionStart, String syncMode = 'both', bool force = false, String? coreOverride, String? emulatorId}) async {
     try {
-      final strategy = getStrategyForSlug(game.platformSlug, emulatorId: emulatorId);
+      final strategy = getStrategyForGame(game, emulatorId: emulatorId);
       if (strategy == null) {
         debugPrint('[SaveSync] [push] No save strategy for slug="${game.platformSlug}"');
         return false;
@@ -898,7 +912,7 @@ class SaveSyncService {
   /// Uses stored last-pull timestamps for freshness checks.
   Future<bool> _legacyPullSave(Game game, String romPath, {Map<String, dynamic>? saveData, String? coreOverride, String? emulatorId}) async {
     try {
-      final strategy = getStrategyForSlug(game.platformSlug, emulatorId: emulatorId);
+      final strategy = getStrategyForGame(game, emulatorId: emulatorId);
       if (strategy == null) {
         debugPrint('[SaveSync] [pull] No save strategy for slug="${game.platformSlug}"');
         return false;

--- a/lib/ui/screens/library_actions.dart
+++ b/lib/ui/screens/library_actions.dart
@@ -593,7 +593,7 @@ mixin LibraryActionsMixin<T extends ConsumerStatefulWidget> on ConsumerState<T> 
 
   Future<dynamic> _handleSyncError(BuildContext context, dynamic e, Game game, String romPath, SaveSyncService syncService, String syncMode, {required bool push}) async {
     if (e is SaveMappingRequiredException) {
-      final strategy = syncService.getStrategyForSlug(game.platformSlug);
+      final strategy = syncService.getStrategyForGame(game);
       final selectedFolder = await LibraryDialogService.showFolderMappingDialog(context, strategy);
       if (selectedFolder != null) {
         await syncService.saveMappedFolder(game.id, selectedFolder);

--- a/test/unit/save_strategy_platform_zip_test.dart
+++ b/test/unit/save_strategy_platform_zip_test.dart
@@ -29,6 +29,7 @@ void main() {
     
     when(mockStrategyRegistry.getPreferredEmulatorId(any)).thenReturn(null);
     when(mockStrategyRegistry.getStrategyForSlug(any)).thenReturn(null);
+    when(mockStrategyRegistry.getGameEmulatorPreference(any)).thenReturn(null);
     
     when(mockDirectoryService.getEmulatorAppSupportDirectory(any, platformSlug: anyNamed('platformSlug')))
         .thenAnswer((_) async => '/nonexistent_directory_for_testing');

--- a/test/unit/save_sync_regression_test.dart
+++ b/test/unit/save_sync_regression_test.dart
@@ -29,6 +29,7 @@ void main() {
 
     when(mockStrategyRegistry.getPreferredEmulatorId(any)).thenReturn(null);
     when(mockStrategyRegistry.getStrategyForSlug(any)).thenReturn(null);
+    when(mockStrategyRegistry.getGameEmulatorPreference(any)).thenReturn(null);
     when(mockDirectoryService.getEmulatorAppSupportDirectory(any,
             platformSlug: anyNamed('platformSlug')))
         .thenAnswer((_) async => '/nonexistent_directory_for_testing');

--- a/test/unit/save_sync_service_test.dart
+++ b/test/unit/save_sync_service_test.dart
@@ -29,6 +29,7 @@ void main() {
     // Default preferred emulator is null to use built-in fallbacks
     when(mockStrategyRegistry.getPreferredEmulatorId(any)).thenReturn(null);
     when(mockStrategyRegistry.getStrategyForSlug(any)).thenReturn(null);
+    when(mockStrategyRegistry.getGameEmulatorPreference(any)).thenReturn(null);
     
     // Ensure that on Linux tests we don't accidentally pick up a real system directory or a mock that returns empty string
     when(mockDirectoryService.getEmulatorAppSupportDirectory(any))


### PR DESCRIPTION
## Summary

`SaveSyncService` had several call sites that could silently ignore a per-game
emulator preference and fall back to the platform-wide default emulator
instead — the same root cause as #79, but for code paths that were never
updated when #79's launch-time fix went in.

#79's fix made *launch* always pass the emulator that actually started the
game through to `pullSave(..., emulatorId: strategy.emulatorId)`. But these
call sites never received an `emulatorId` at all, so they had no way to
honor a per-game preference on their own:

- `SaveSyncService.pushSaves()` (both the device-sync and legacy paths)
- Two of the manual `pullSave()` call sites in the library UI
- `BackupService.createImmediate()` / `BackupService.restore()`

Concretely: if you set a per-game emulator override (e.g. "always use PCSX2
for this game" from the per-game launch picker) instead of a platform-wide
default, manually pushing/pulling a save for that game — or the automatic
post-exit backup — could still resolve the platform's default emulator's
save strategy instead, silently reading/writing the wrong emulator's save
folder.

This looks like it explains #94 as well: the reporter's own debug logs show
save sync resolving RetroArch despite having "configured PCSX2 to be
launcher default," which matches this exact gap. I haven't been able to
verify against their specific setup, so flagging it here rather than
asserting it closes that issue outright — happy to follow up on that thread
if it needs more from me.

## Fix

Adds `SaveSyncService.getStrategyForGame(Game game, {String? emulatorId})`,
which resolves `StrategyRegistry.getGameEmulatorPreference(game.id)` as a
fallback whenever the caller doesn't already know which emulator launched
the game, before delegating to the existing `getStrategyForSlug` precedence
(explicit emulatorId → per-game preference → platform preference → default).
Switched all the call sites above to use it.

## Test plan

- [x] `flutter test` — full suite passes (829 tests)
- [x] `dart analyze` — no new issues
- [x] Added `getGameEmulatorPreference` stubs to the existing mocked
      `StrategyRegistry` test fixtures where needed (Mockito's strict mocks
      throw on any unstubbed call)

Refs #79, possibly #94 (see note above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
